### PR TITLE
Add practice lead authorization workflow

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -9,9 +9,10 @@ A FastAPI application that enables Slalom consultants to register their capabili
 ## Features
 
 - View all available consulting capabilities
-- Register consultant expertise and availability
+- Submit consultant access requests for practice lead review
+- Practice lead sign-in with role-based capability management
 - Track skill levels and certifications
-- Manage capability capacity and team assignments
+- Audit capability changes and approvals
 
 ## Getting Started
 
@@ -36,9 +37,15 @@ A FastAPI application that enables Slalom consultants to register their capabili
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/capabilities`                                                   | Get all capabilities with details and current consultant assignments |
-| POST   | `/capabilities/{capability_name}/register?email=consultant@slalom.com` | Register consultant for a capability                     |
-| DELETE | `/capabilities/{capability_name}/unregister?email=consultant@slalom.com` | Unregister consultant from a capability              |
+| GET    | `/auth/session`                                                   | Get the current session state                                       |
+| POST   | `/auth/login`                                                     | Sign in as a practice lead                                          |
+| POST   | `/auth/logout`                                                    | End the current session                                             |
+| GET    | `/capabilities`                                                   | Get capabilities, consultants, and pending requests                 |
+| POST   | `/capabilities/{capability_name}/request-access`                  | Submit a consultant access request                                  |
+| POST   | `/capabilities/{capability_name}/register`                        | Register a consultant directly as a practice lead                   |
+| POST   | `/capabilities/{capability_name}/approve-request`                 | Approve a pending consultant request                                |
+| DELETE | `/capabilities/{capability_name}/unregister?email=consultant@slalom.com` | Unregister a consultant as a practice lead                  |
+| GET    | `/audit-log`                                                      | View recent auditable management activity                           |
 
 ## Data Model
 
@@ -62,6 +69,18 @@ The application uses a consulting-focused data model:
    - Availability
 
 All data is currently stored in memory for this learning exercise. In a production environment, this would be backed by a robust database system.
+
+## Demo Practice Lead Accounts
+
+Practice lead credentials live in `src/practice_leads.json` with salted PBKDF2 password hashes.
+
+- Username: `karima.lead`
+- Password: `slalom-admin-2026`
+- Scope: all practice areas
+
+- Username: `taylor.practice`
+- Password: `slalom-tech-2026`
+- Scope: Technology only
 
 ## Future Enhancements
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,23 +1,28 @@
-"""
-Slalom Capabilities Management System API
+"""Slalom Capabilities Management System API."""
 
-A FastAPI application that enables Slalom consultants to register their
-capabilities and manage consulting expertise across the organization.
-"""
-
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
-import os
+import hashlib
+import json
+import secrets
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 app = FastAPI(title="Slalom Capabilities Management API",
               description="API for managing consulting capabilities and consultant expertise")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app.mount("/static", StaticFiles(directory=current_dir / "static"), name="static")
+
+PRACTICE_LEADS_FILE = current_dir / "practice_leads.json"
+SESSION_COOKIE_NAME = "slalom_session"
+SESSION_MAX_AGE_SECONDS = 8 * 60 * 60
+PASSWORD_HASH_ITERATIONS = 120000
 
 # In-memory capabilities database
 capabilities = {
@@ -104,56 +109,277 @@ capabilities = {
     }
 }
 
+pending_requests = {capability_name: [] for capability_name in capabilities}
+sessions: dict[str, dict[str, Any]] = {}
+audit_log: list[dict[str, Any]] = []
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class CapabilityEmailRequest(BaseModel):
+    email: str
+
+
+def load_practice_leads() -> dict[str, dict[str, Any]]:
+    with PRACTICE_LEADS_FILE.open("r", encoding="utf-8") as file_handle:
+        practice_leads = json.load(file_handle)
+
+    return {lead["username"]: lead for lead in practice_leads}
+
+
+practice_leads = load_practice_leads()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def verify_password(password: str, salt_hex: str, password_hash_hex: str) -> bool:
+    salt = bytes.fromhex(salt_hex)
+    expected_hash = bytes.fromhex(password_hash_hex)
+    candidate_hash = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        PASSWORD_HASH_ITERATIONS,
+    )
+    return secrets.compare_digest(candidate_hash, expected_hash)
+
+
+def normalize_email(email: str) -> str:
+    normalized_email = email.strip().lower()
+    if not normalized_email or "@" not in normalized_email:
+        raise HTTPException(status_code=400, detail="Provide a valid consultant email address")
+    if not normalized_email.endswith("@slalom.com"):
+        raise HTTPException(status_code=400, detail="Use a @slalom.com email address")
+    return normalized_email
+
+
+def get_capability(capability_name: str) -> dict[str, Any]:
+    capability = capabilities.get(capability_name)
+    if capability is None:
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return capability
+
+
+def get_current_user(request: Request) -> dict[str, Any] | None:
+    session_token = request.cookies.get(SESSION_COOKIE_NAME)
+    if not session_token:
+        return None
+    return sessions.get(session_token)
+
+
+def can_manage_capability(user: dict[str, Any] | None, capability_name: str) -> bool:
+    if not user or user.get("role") != "practice_lead":
+        return False
+
+    permitted_practice_areas = user.get("practice_areas", [])
+    capability_practice_area = capabilities[capability_name]["practice_area"]
+    return "*" in permitted_practice_areas or capability_practice_area in permitted_practice_areas
+
+
+def require_practice_lead(request: Request, capability_name: str | None = None) -> dict[str, Any]:
+    current_user = get_current_user(request)
+    if current_user is None:
+        raise HTTPException(status_code=401, detail="Practice lead login required")
+    if current_user.get("role") != "practice_lead":
+        raise HTTPException(status_code=403, detail="Practice lead access required")
+    if capability_name and not can_manage_capability(current_user, capability_name):
+        raise HTTPException(
+            status_code=403,
+            detail="You do not have permission to manage this practice area",
+        )
+    return current_user
+
+
+def append_audit_entry(
+    action: str,
+    actor: str,
+    capability_name: str | None = None,
+    consultant_email: str | None = None,
+) -> None:
+    audit_log.insert(
+        0,
+        {
+            "timestamp": utc_now(),
+            "action": action,
+            "actor": actor,
+            "capability_name": capability_name,
+            "consultant_email": consultant_email,
+        },
+    )
+
+
+def build_capabilities_response(current_user: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    response_payload = {}
+    for capability_name, capability_details in capabilities.items():
+        response_payload[capability_name] = {
+            **capability_details,
+            "consultants": list(capability_details["consultants"]),
+            "pending_requests": list(pending_requests[capability_name]),
+            "can_manage": can_manage_capability(current_user, capability_name),
+        }
+    return response_payload
+
 
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.get("/auth/session")
+def auth_session(request: Request):
+    current_user = get_current_user(request)
+    if current_user is None:
+        return {
+            "authenticated": False,
+            "role": "consultant",
+            "display_name": "Consultant self-service",
+            "practice_areas": [],
+        }
+
+    return {
+        "authenticated": True,
+        "role": current_user["role"],
+        "username": current_user["username"],
+        "display_name": current_user["display_name"],
+        "practice_areas": current_user.get("practice_areas", []),
+    }
+
+
+@app.post("/auth/login")
+def login(credentials: LoginRequest):
+    practice_lead = practice_leads.get(credentials.username.strip())
+    if practice_lead is None or not verify_password(
+        credentials.password,
+        practice_lead["salt"],
+        practice_lead["password_hash"],
+    ):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    session_token = secrets.token_urlsafe(32)
+    sessions[session_token] = {
+        "username": practice_lead["username"],
+        "display_name": practice_lead["display_name"],
+        "role": practice_lead["role"],
+        "practice_areas": practice_lead["practice_areas"],
+    }
+
+    append_audit_entry("login", practice_lead["username"])
+
+    response = JSONResponse(
+        {
+            "message": f"Signed in as {practice_lead['display_name']}",
+            "user": sessions[session_token],
+        }
+    )
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=session_token,
+        httponly=True,
+        samesite="lax",
+        max_age=SESSION_MAX_AGE_SECONDS,
+    )
+    return response
+
+
+@app.post("/auth/logout")
+def logout(request: Request):
+    session_token = request.cookies.get(SESSION_COOKIE_NAME)
+    current_user = get_current_user(request)
+    if session_token:
+        sessions.pop(session_token, None)
+
+    if current_user is not None:
+        append_audit_entry("logout", current_user["username"])
+
+    response = JSONResponse({"message": "Signed out"})
+    response.delete_cookie(SESSION_COOKIE_NAME)
+    return response
+
+
 @app.get("/capabilities")
-def get_capabilities():
-    return capabilities
+def get_capabilities(request: Request):
+    return build_capabilities_response(get_current_user(request))
+
+
+@app.get("/audit-log")
+def get_audit_log(request: Request):
+    current_user = require_practice_lead(request)
+    permitted_practice_areas = current_user.get("practice_areas", [])
+
+    def is_visible(entry: dict[str, Any]) -> bool:
+        capability_name = entry.get("capability_name")
+        if capability_name is None:
+            return True
+        capability_practice_area = capabilities[capability_name]["practice_area"]
+        return "*" in permitted_practice_areas or capability_practice_area in permitted_practice_areas
+
+    return [entry for entry in audit_log if is_visible(entry)][:25]
+
+
+@app.post("/capabilities/{capability_name}/request-access")
+def request_capability_access(capability_name: str, registration: CapabilityEmailRequest):
+    capability = get_capability(capability_name)
+    email = normalize_email(registration.email)
+
+    if email in capability["consultants"]:
+        raise HTTPException(status_code=400, detail="Consultant is already registered for this capability")
+    if email in pending_requests[capability_name]:
+        raise HTTPException(status_code=400, detail="A request for this consultant is already pending")
+
+    pending_requests[capability_name].append(email)
+    append_audit_entry("request_submitted", email, capability_name, email)
+    return {"message": f"Submitted a registration request for {email} in {capability_name}"}
 
 
 @app.post("/capabilities/{capability_name}/register")
-def register_for_capability(capability_name: str, email: str):
-    """Register a consultant for a capability"""
-    # Validate capability exists
-    if capability_name not in capabilities:
-        raise HTTPException(status_code=404, detail="Capability not found")
+def register_for_capability(capability_name: str, registration: CapabilityEmailRequest, request: Request):
+    current_user = require_practice_lead(request, capability_name)
+    capability = get_capability(capability_name)
+    email = normalize_email(registration.email)
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
-
-    # Validate consultant is not already registered
     if email in capability["consultants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Consultant is already registered for this capability"
-        )
+        raise HTTPException(status_code=400, detail="Consultant is already registered for this capability")
 
-    # Add consultant
     capability["consultants"].append(email)
+    if email in pending_requests[capability_name]:
+        pending_requests[capability_name].remove(email)
+
+    append_audit_entry("registered", current_user["username"], capability_name, email)
     return {"message": f"Registered {email} for {capability_name}"}
 
 
+@app.post("/capabilities/{capability_name}/approve-request")
+def approve_capability_request(capability_name: str, registration: CapabilityEmailRequest, request: Request):
+    current_user = require_practice_lead(request, capability_name)
+    capability = get_capability(capability_name)
+    email = normalize_email(registration.email)
+
+    if email not in pending_requests[capability_name]:
+        raise HTTPException(status_code=404, detail="Pending request not found")
+    if email in capability["consultants"]:
+        pending_requests[capability_name].remove(email)
+        raise HTTPException(status_code=400, detail="Consultant is already registered for this capability")
+
+    pending_requests[capability_name].remove(email)
+    capability["consultants"].append(email)
+    append_audit_entry("request_approved", current_user["username"], capability_name, email)
+    return {"message": f"Approved {email} for {capability_name}"}
+
+
 @app.delete("/capabilities/{capability_name}/unregister")
-def unregister_from_capability(capability_name: str, email: str):
-    """Unregister a consultant from a capability"""
-    # Validate capability exists
-    if capability_name not in capabilities:
-        raise HTTPException(status_code=404, detail="Capability not found")
+def unregister_from_capability(capability_name: str, email: str, request: Request):
+    current_user = require_practice_lead(request, capability_name)
+    capability = get_capability(capability_name)
+    normalized_email = normalize_email(email)
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
+    if normalized_email not in capability["consultants"]:
+        raise HTTPException(status_code=400, detail="Consultant is not registered for this capability")
 
-    # Validate consultant is registered
-    if email not in capability["consultants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Consultant is not registered for this capability"
-        )
-
-    # Remove consultant
-    capability["consultants"].remove(email)
-    return {"message": f"Unregistered {email} from {capability_name}"}
+    capability["consultants"].remove(normalized_email)
+    append_audit_entry("unregistered", current_user["username"], capability_name, normalized_email)
+    return {"message": f"Unregistered {normalized_email} from {capability_name}"}

--- a/src/practice_leads.json
+++ b/src/practice_leads.json
@@ -1,0 +1,18 @@
+[
+  {
+    "username": "karima.lead",
+    "display_name": "Karima Slalom",
+    "role": "practice_lead",
+    "practice_areas": ["*"],
+    "salt": "de5b0b72f9050c195ecf8474f4b9b483",
+    "password_hash": "dc2e92e7a1d5013f3ecc751b434e503a4de55d91d89449bc6910bd3c70aee248"
+  },
+  {
+    "username": "taylor.practice",
+    "display_name": "Taylor Practice",
+    "role": "practice_lead",
+    "practice_areas": ["Technology"],
+    "salt": "f7d99acd23b5f4cce87f6f3daf29a7f9",
+    "password_hash": "1ca0a86733e9e9fd78be2610e1f849fb11bd262fdd1790c86dda2bde6f82a9d1"
+  }
+]

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,162 +1,336 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const state = {
+    session: {
+      authenticated: false,
+      role: "consultant",
+      display_name: "Consultant self-service",
+      practice_areas: [],
+    },
+  };
+
   const capabilitiesList = document.getElementById("capabilities-list");
   const capabilitySelect = document.getElementById("capability");
   const registerForm = document.getElementById("register-form");
   const messageDiv = document.getElementById("message");
+  const workflowTitle = document.getElementById("workflow-title");
+  const workflowDescription = document.getElementById("workflow-description");
+  const workflowNote = document.getElementById("workflow-note");
+  const submitButton = document.getElementById("submit-button");
+  const authStatus = document.getElementById("auth-status");
+  const loginButton = document.getElementById("login-button");
+  const logoutButton = document.getElementById("logout-button");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+  const cancelLoginButton = document.getElementById("cancel-login");
+  const modalBackdrop = document.getElementById("modal-backdrop");
+  const auditPanel = document.getElementById("audit-panel");
+  const auditList = document.getElementById("audit-list");
 
-  // Function to fetch capabilities from API
+  function showMessage(target, text, kind) {
+    target.textContent = text;
+    target.className = kind;
+    target.classList.remove("hidden");
+  }
+
+  function hideMessage(target) {
+    target.classList.add("hidden");
+  }
+
+  function canManage(details) {
+    const practiceAreas = state.session.practice_areas || [];
+    return state.session.authenticated && (practiceAreas.includes("*") || practiceAreas.includes(details.practice_area));
+  }
+
+  function updateWorkflowText() {
+    if (state.session.authenticated) {
+      workflowTitle.textContent = "Register or Review Consultants";
+      workflowDescription.textContent = "Practice leads can register consultants directly, approve pending requests, and remove assignments for permitted practice areas.";
+      workflowNote.textContent = "Pending requests appear on each capability card, and all management actions are written to the audit activity feed.";
+      submitButton.textContent = "Register Consultant";
+      authStatus.textContent = `${state.session.display_name} signed in as Practice Lead`;
+      loginButton.classList.add("hidden");
+      logoutButton.classList.remove("hidden");
+      auditPanel.classList.remove("hidden");
+    } else {
+      workflowTitle.textContent = "Request Capability Access";
+      workflowDescription.textContent = "Consultants can submit access requests for a practice lead to review. Direct capability changes require practice lead sign-in.";
+      workflowNote.textContent = "Sign in as a practice lead to approve pending requests and manage consultant assignments.";
+      submitButton.textContent = "Submit Access Request";
+      authStatus.textContent = "Consultant self-service mode";
+      loginButton.classList.remove("hidden");
+      logoutButton.classList.add("hidden");
+      auditPanel.classList.add("hidden");
+    }
+  }
+
+  function populateCapabilitySelect(capabilities) {
+    capabilitySelect.innerHTML = '<option value="">-- Select a capability --</option>';
+
+    Object.keys(capabilities).forEach((name) => {
+      const option = document.createElement("option");
+      option.value = name;
+      option.textContent = name;
+      capabilitySelect.appendChild(option);
+    });
+  }
+
+  function renderAuditLog(entries) {
+    if (!entries.length) {
+      auditList.innerHTML = "<li>No audit activity recorded yet.</li>";
+      return;
+    }
+
+    auditList.innerHTML = entries
+      .map((entry) => {
+        const capabilityLabel = entry.capability_name ? ` on ${entry.capability_name}` : "";
+        const consultantLabel = entry.consultant_email ? ` for ${entry.consultant_email}` : "";
+        return `<li><strong>${entry.action.replaceAll("_", " ")}</strong> by ${entry.actor}${consultantLabel}${capabilityLabel}<span>${new Date(entry.timestamp).toLocaleString()}</span></li>`;
+      })
+      .join("");
+  }
+
+  function renderCapabilities(capabilities) {
+    capabilitiesList.innerHTML = "";
+
+    Object.entries(capabilities).forEach(([name, details]) => {
+      const capabilityCard = document.createElement("div");
+      capabilityCard.className = "capability-card";
+
+      const consultantsHTML = details.consultants.length
+        ? `<div class="consultants-section">
+            <h5>Registered Consultants</h5>
+            <ul class="consultants-list">
+              ${details.consultants
+                .map((email) => {
+                  const actionButton = canManage(details)
+                    ? `<button class="delete-btn" data-action="unregister" data-capability="${name}" data-email="${email}">Remove</button>`
+                    : "";
+                  return `<li><span class="consultant-email">${email}</span>${actionButton}</li>`;
+                })
+                .join("")}
+            </ul>
+          </div>`
+        : "<p><em>No consultants registered yet</em></p>";
+
+      const pendingHTML = canManage(details) && details.pending_requests.length
+        ? `<div class="pending-section">
+            <h5>Pending Requests</h5>
+            <ul class="consultants-list pending-list">
+              ${details.pending_requests
+                .map(
+                  (email) => `<li><span class="consultant-email">${email}</span><button class="approve-btn" data-action="approve" data-capability="${name}" data-email="${email}">Approve</button></li>`
+                )
+                .join("")}
+            </ul>
+          </div>`
+        : "";
+
+      const managementBadge = canManage(details)
+        ? '<span class="management-badge">Practice lead access</span>'
+        : "";
+
+      capabilityCard.innerHTML = `
+        <div class="card-header">
+          <h4>${name}</h4>
+          ${managementBadge}
+        </div>
+        <p>${details.description}</p>
+        <p><strong>Practice Area:</strong> ${details.practice_area}</p>
+        <p><strong>Industry Verticals:</strong> ${details.industry_verticals.join(", ")}</p>
+        <p><strong>Capacity:</strong> ${details.capacity} hours/week available</p>
+        <p><strong>Current Team:</strong> ${details.consultants.length} consultants</p>
+        <div class="consultants-container">
+          ${consultantsHTML}
+          ${pendingHTML}
+        </div>
+      `;
+
+      capabilitiesList.appendChild(capabilityCard);
+    });
+  }
+
+  async function fetchSession() {
+    const response = await fetch("/auth/session", { credentials: "same-origin" });
+    state.session = await response.json();
+    updateWorkflowText();
+  }
+
   async function fetchCapabilities() {
     try {
-      const response = await fetch("/capabilities");
+      const response = await fetch("/capabilities", { credentials: "same-origin" });
       const capabilities = await response.json();
-
-      // Clear loading message
-      capabilitiesList.innerHTML = "";
-
-      // Populate capabilities list
-      Object.entries(capabilities).forEach(([name, details]) => {
-        const capabilityCard = document.createElement("div");
-        capabilityCard.className = "capability-card";
-
-        const availableCapacity = details.capacity || 0;
-        const currentConsultants = details.consultants ? details.consultants.length : 0;
-
-        // Create consultants HTML with delete icons
-        const consultantsHTML =
-          details.consultants && details.consultants.length > 0
-            ? `<div class="consultants-section">
-              <h5>Registered Consultants:</h5>
-              <ul class="consultants-list">
-                ${details.consultants
-                  .map(
-                    (email) =>
-                      `<li><span class="consultant-email">${email}</span><button class="delete-btn" data-capability="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
-            : `<p><em>No consultants registered yet</em></p>`;
-
-        capabilityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Practice Area:</strong> ${details.practice_area}</p>
-          <p><strong>Industry Verticals:</strong> ${details.industry_verticals ? details.industry_verticals.join(', ') : 'Not specified'}</p>
-          <p><strong>Capacity:</strong> ${availableCapacity} hours/week available</p>
-          <p><strong>Current Team:</strong> ${currentConsultants} consultants</p>
-          <div class="consultants-container">
-            ${consultantsHTML}
-          </div>
-        `;
-
-        capabilitiesList.appendChild(capabilityCard);
-
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        capabilitySelect.appendChild(option);
-      });
-
-      // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      populateCapabilitySelect(capabilities);
+      renderCapabilities(capabilities);
     } catch (error) {
-      capabilitiesList.innerHTML =
-        "<p>Failed to load capabilities. Please try again later.</p>";
+      capabilitiesList.innerHTML = "<p>Failed to load capabilities. Please try again later.</p>";
       console.error("Error fetching capabilities:", error);
     }
   }
 
-  // Handle unregister functionality
-  async function handleUnregister(event) {
-    const button = event.target;
-    const capability = button.getAttribute("data-capability");
-    const email = button.getAttribute("data-email");
+  async function fetchAuditLog() {
+    if (!state.session.authenticated) {
+      return;
+    }
 
     try {
-      const response = await fetch(
-        `/capabilities/${encodeURIComponent(
-          capability
-        )}/unregister?email=${encodeURIComponent(email)}`,
-        {
-          method: "DELETE",
-        }
-      );
+      const response = await fetch("/audit-log", { credentials: "same-origin" });
+      const entries = await response.json();
+      renderAuditLog(entries);
+    } catch (error) {
+      auditList.innerHTML = "<li>Unable to load audit activity.</li>";
+      console.error("Error fetching audit log:", error);
+    }
+  }
+
+  async function refreshApp() {
+    await fetchSession();
+    await fetchCapabilities();
+    if (state.session.authenticated) {
+      await fetchAuditLog();
+    }
+  }
+
+  async function handleCapabilityAction(event) {
+    const button = event.target.closest("button[data-action]");
+    if (!button) {
+      return;
+    }
+
+    const capability = button.getAttribute("data-capability");
+    const email = button.getAttribute("data-email");
+    const action = button.getAttribute("data-action");
+
+    try {
+      let response;
+
+      if (action === "unregister") {
+        response = await fetch(
+          `/capabilities/${encodeURIComponent(capability)}/unregister?email=${encodeURIComponent(email)}`,
+          {
+            method: "DELETE",
+            credentials: "same-origin",
+          }
+        );
+      } else if (action === "approve") {
+        response = await fetch(`/capabilities/${encodeURIComponent(capability)}/approve-request`, {
+          method: "POST",
+          credentials: "same-origin",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ email }),
+        });
+      }
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-
-        // Refresh capabilities list to show updated consultants
-        fetchCapabilities();
+        showMessage(messageDiv, result.message, "success");
+        await refreshApp();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(messageDiv, result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
-      console.error("Error unregistering:", error);
+      showMessage(messageDiv, "The requested change could not be completed.", "error");
+      console.error("Capability action failed:", error);
     }
   }
 
-  // Handle form submission
+  function openLoginModal() {
+    loginModal.classList.remove("hidden");
+    loginModal.setAttribute("aria-hidden", "false");
+    hideMessage(loginMessage);
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+    loginModal.setAttribute("aria-hidden", "true");
+    loginForm.reset();
+    hideMessage(loginMessage);
+  }
+
+  capabilitiesList.addEventListener("click", handleCapabilityAction);
+
   registerForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
     const email = document.getElementById("email").value;
-    const capability = document.getElementById("capability").value;
+    const capability = capabilitySelect.value;
+    const endpoint = state.session.authenticated ? "register" : "request-access";
 
     try {
-      const response = await fetch(
-        `/capabilities/${encodeURIComponent(
-          capability
-        )}/register?email=${encodeURIComponent(email)}`,
-        {
-          method: "POST",
-        }
-      );
+      const response = await fetch(`/capabilities/${encodeURIComponent(capability)}/${endpoint}`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
 
       const result = await response.json();
-
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(messageDiv, result.message, "success");
         registerForm.reset();
-
-        // Refresh capabilities list to show updated consultants
-        fetchCapabilities();
+        await refreshApp();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(messageDiv, result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to register. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
-      console.error("Error registering:", error);
+      showMessage(messageDiv, "Failed to submit the request.", "error");
+      console.error("Form submission failed:", error);
     }
   });
 
-  // Initialize app
-  fetchCapabilities();
+  loginButton.addEventListener("click", openLoginModal);
+  cancelLoginButton.addEventListener("click", closeLoginModal);
+  modalBackdrop.addEventListener("click", closeLoginModal);
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+      if (response.ok) {
+        closeLoginModal();
+        showMessage(messageDiv, result.message, "success");
+        await refreshApp();
+      } else {
+        showMessage(loginMessage, result.detail || "Sign in failed", "error");
+      }
+    } catch (error) {
+      showMessage(loginMessage, "Sign in failed. Please try again.", "error");
+      console.error("Login failed:", error);
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", {
+        method: "POST",
+        credentials: "same-origin",
+      });
+      const result = await response.json();
+      showMessage(messageDiv, result.message, "success");
+      await refreshApp();
+    } catch (error) {
+      showMessage(messageDiv, "Sign out failed. Please try again.", "error");
+      console.error("Logout failed:", error);
+    }
+  });
+
+  refreshApp();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,11 +8,20 @@
   </head>
   <body>
     <header>
-      <div class="header-content">
-        <img src="https://colby-timm.github.io/images/byte-teacher.png" alt="Byte mascot" class="mascot" />
-        <div class="header-text">
-          <h1>Slalom Capabilities Management</h1>
-          <h2>Consulting Expertise Platform</h2>
+      <div class="header-bar">
+        <div class="header-content">
+          <img src="https://colby-timm.github.io/images/byte-teacher.png" alt="Byte mascot" class="mascot" />
+          <div class="header-text">
+            <h1>Slalom Capabilities Management</h1>
+            <h2>Consulting Expertise Platform</h2>
+          </div>
+        </div>
+        <div class="auth-controls">
+          <div id="auth-status" class="auth-status">Consultant self-service mode</div>
+          <div class="auth-actions">
+            <button id="login-button" type="button" class="secondary-button">Practice Lead Sign In</button>
+            <button id="logout-button" type="button" class="secondary-button hidden">Sign Out</button>
+          </div>
         </div>
       </div>
     </header>
@@ -21,30 +30,67 @@
       <section id="capabilities-container">
         <h3>Available Capabilities</h3>
         <div id="capabilities-list">
-          <!-- Capabilities will be loaded here -->
           <p>Loading capabilities...</p>
         </div>
       </section>
 
-      <section id="register-container">
-        <h3>Register Your Expertise</h3>
-        <form id="register-form">
-          <div class="form-group">
-            <label for="email">Consultant Email:</label>
-            <input type="email" id="email" required placeholder="your-email@slalom.com" />
-          </div>
-          <div class="form-group">
-            <label for="capability">Select Capability:</label>
-            <select id="capability" required>
-              <option value="">-- Select a capability --</option>
-              <!-- Capability options will be loaded here -->
-            </select>
-          </div>
-          <button type="submit">Register Expertise</button>
-        </form>
-        <div id="message" class="hidden"></div>
+      <section id="control-panel">
+        <div class="panel-block">
+          <h3 id="workflow-title">Request Capability Access</h3>
+          <p id="workflow-description" class="panel-description">
+            Consultants can submit access requests. Practice leads can sign in to approve requests,
+            register consultants directly, and remove assignments.
+          </p>
+          <form id="register-form">
+            <div class="form-group">
+              <label for="email">Consultant Email:</label>
+              <input type="email" id="email" required placeholder="your-email@slalom.com" />
+            </div>
+            <div class="form-group">
+              <label for="capability">Select Capability:</label>
+              <select id="capability" required>
+                <option value="">-- Select a capability --</option>
+              </select>
+            </div>
+            <button id="submit-button" type="submit">Submit Access Request</button>
+          </form>
+          <div id="message" class="hidden"></div>
+          <p id="workflow-note" class="helper-text">
+            Sign in as a practice lead to approve pending requests and manage consultant assignments.
+          </p>
+        </div>
+
+        <div id="audit-panel" class="panel-block hidden">
+          <h3>Recent Audit Activity</h3>
+          <ul id="audit-list" class="audit-list"></ul>
+        </div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden" aria-hidden="true">
+      <div class="modal-backdrop" id="modal-backdrop"></div>
+      <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="login-title">
+        <h3 id="login-title">Practice Lead Sign In</h3>
+        <p class="panel-description">
+          Sign in with a practice lead account to review requests, approve registrations, and manage assignments.
+        </p>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required autocomplete="current-password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Sign In</button>
+            <button id="cancel-login" type="button" class="secondary-button">Cancel</button>
+          </div>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
 
     <footer>
       <div class="footer-content">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,7 +16,6 @@ body {
 }
 
 header {
-  text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background: linear-gradient(135deg, #003d7a, #0066cc);
@@ -25,11 +24,37 @@ header {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 24px;
+}
+
 .header-content {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 20px;
+  flex-wrap: wrap;
+}
+
+.auth-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.auth-status {
+  font-size: 0.95rem;
+  color: #e3f2fd;
+}
+
+.auth-actions {
+  display: flex;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
@@ -52,16 +77,10 @@ header {
 }
 
 main {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(320px, 1fr);
   gap: 30px;
-  justify-content: center;
-}
-
-@media (min-width: 768px) {
-  main {
-    grid-template-columns: 2fr 1fr;
-  }
+  align-items: start;
 }
 
 section {
@@ -69,8 +88,25 @@ section {
   padding: 20px;
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  width: 100%;
-  max-width: 500px;
+}
+
+#control-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.panel-block {
+  background-color: white;
+  padding: 20px;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.panel-description,
+.helper-text {
+  margin-bottom: 15px;
+  color: #4c5d73;
 }
 
 section h3 {
@@ -89,6 +125,25 @@ section h3 {
   background: linear-gradient(145deg, #ffffff, #f8f9fa);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.management-badge {
+  background: rgba(0, 102, 204, 0.1);
+  color: #003d7a;
+  border: 1px solid rgba(0, 102, 204, 0.2);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .capability-card:hover {
@@ -114,6 +169,12 @@ section h3 {
   margin-top: 15px;
   padding-top: 12px;
   border-top: 1px dashed #0066cc;
+}
+
+.pending-section {
+  margin-top: 18px;
+  padding-top: 12px;
+  border-top: 1px dashed #8bb7e8;
 }
 
 .consultants-section h5 {
@@ -164,6 +225,25 @@ section h3 {
   transform: scale(1.05);
 }
 
+.approve-btn,
+.secondary-button {
+  background: white;
+  border: 1px solid #d0d8e5;
+  color: #003d7a;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 7px 10px;
+  transition: all 0.2s;
+  border-radius: 6px;
+  font-weight: 700;
+}
+
+.approve-btn:hover,
+.secondary-button:hover {
+  border-color: #0066cc;
+  background: #eef5ff;
+}
+
 .consultants-section p {
   color: #666;
   font-style: italic;
@@ -210,6 +290,57 @@ button[type="submit"]:hover {
   background: linear-gradient(135deg, #0066cc, #1976d2);
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 61, 122, 0.3);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 22, 44, 0.55);
+}
+
+.modal-content {
+  position: relative;
+  width: min(460px, calc(100vw - 32px));
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 20px 40px rgba(6, 22, 44, 0.25);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.audit-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.audit-list li {
+  border: 1px solid #e3e8ef;
+  border-radius: 8px;
+  padding: 12px;
+  background: #f8fbff;
+}
+
+.audit-list span {
+  display: block;
+  margin-top: 6px;
+  color: #63748a;
+  font-size: 0.88rem;
 }
 
 .message {
@@ -287,9 +418,35 @@ footer {
 
 /* Responsive design improvements */
 @media (max-width: 768px) {
+  body {
+    padding: 14px;
+  }
+
+  .header-bar {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0 16px;
+  }
+
   .header-content {
     flex-direction: column;
     gap: 10px;
+  }
+
+  .auth-controls {
+    align-items: stretch;
+  }
+
+  .auth-actions {
+    width: 100%;
+  }
+
+  .auth-actions button {
+    width: 100%;
+  }
+
+  main {
+    grid-template-columns: 1fr;
   }
   
   .mascot {
@@ -303,5 +460,10 @@ footer {
   
   .header-text h2 {
     font-size: 1rem;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add practice lead authentication with scoped practice-area permissions
- change consultant self-service to submit access requests instead of directly editing assignments
- add approval and unregister management flows plus a lightweight audit activity feed

## Validation
- verified anonymous users can submit requests but cannot unregister consultants
- verified practice leads can sign in, approve requests, and unregister consultants
- verified a Technology-scoped lead receives a 403 when trying to manage a Strategy capability
- confirmed no editor errors in the updated backend, frontend, and documentation files
